### PR TITLE
Modifying solution for exercise 26 (In Range) to make start exclusive

### DIFF
--- a/Kotlin Koans/Conventions/In range/Solution.kt
+++ b/Kotlin Koans/Conventions/In range/Solution.kt
@@ -1,5 +1,5 @@
 <answer>class DateRange(val start: MyDate, val endInclusive: MyDate)<taskWindow> {
-    operator fun contains(item: MyDate): Boolean = start <= item && item <= endInclusive
+    operator fun contains(item: MyDate): Boolean = start < item && item <= endInclusive
 }</taskWindow></answer>
 
 fun checkInRange(date: MyDate, first: MyDate, last: MyDate): Boolean {


### PR DESCRIPTION
Hello,

While doing the exercise In Range, I've seen that the solution assumes that start is inclusive. I think it's a mistake, also because end variable is called "endInclusive", while the other is just "start"

Thanks for this nice plugin, and thanks for your time.

If you want anything, don't hesitate to write me.
