### PR TITLE
Remove unnecessary toSet() conversion in Fold solution

### DIFF
--- a/Kotlin Koans/Collections/Fold/Solution.kt
+++ b/Kotlin Koans/Collections/Fold/Solution.kt
@@ -6,6 +6,6 @@ fun Shop.getSetOfProductsOrderedByEveryCustomer(): Set<Product> {
     /*<taskWindow>*/val allProducts = customers.flatMap { it.orders.flatMap { it.products }}.toSet()
     return customers.fold(allProducts, {
         orderedByAll, customer ->
-        orderedByAll.intersect(customer.orders.flatMap { it.products }.toSet())
+        orderedByAll.intersect(customer.orders.flatMap { it.products })
     })/*</taskWindow>*/
 }


### PR DESCRIPTION
Set.intersect(...) parameter is an Iterable rather than a Set.  Link to koan:
    https://try.kotlinlang.org/#/Kotlin%20Koans/Collections/Fold/Task.kt