### PR TITLE
Fix for Kotlin 1.3

### DIFF
--- a/Kotlin Koans/Collections/Compound tasks/Test.kt
+++ b/Kotlin Koans/Collections/Compound tasks/Test.kt
@@ -10,7 +10,7 @@ class K_Compound_Tasks {
     @Test fun testMostExpensiveDeliveredProduct() {
         val testShop = shop("test shop for 'most expensive delivered product'",
                 customer(lucas, Canberra,
-                        order(isDelivered = false, products = idea),
+                        order(isDelivered = false, products = *arrayOf(idea)),
                         order(reSharper)
                 )
         )


### PR DESCRIPTION
Doesn't compile in 1.3 because varargs (when used with named params) needs a collection.