### PR TITLE
Fix punctuation to make koan objective clear

### DIFF
--- a/Kotlin Koans/Introduction/Named arguments/task.md
+++ b/Kotlin Koans/Introduction/Named arguments/task.md
@@ -15,4 +15,4 @@ fun joinToString(
 ```
 
 It can be called on a collection of Strings.
-Specifying only two arguments make the function `joinOptions()` return the list in a JSON format (e.g., "[a, b, c]")
+Specifying only two arguments, make the function `joinOptions()` return the list in a JSON format (e.g., "[a, b, c]")


### PR DESCRIPTION
This comma clarifies that `make` is in the imperative case.